### PR TITLE
feat: 도메인 엔티티 및 JPA Auditing 구성

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -32,24 +32,26 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('account-service/**/*.gradle*', 'account-service/**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
 
       - name: gradlew 실행 권한 부여
+        working-directory: account-service
         run: chmod +x ./gradlew
 
       - name: Gradle로 테스트 실행
+        working-directory: account-service
         run: ./gradlew --info test
 
-      - name: 테스트 결과과
+      - name: 테스트 결과 리포트
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
-          files: '**/build/test-results/test/TEST-*.xml'
+          files: 'account-service/build/test-results/test/TEST-*.xml'
       
       - name: 테스트 결과 게시
         uses: mikepenz/action-junit-report@v4
         if: always()
         with:
-          report_paths: '**/build/test-results/test/TEST-*.xml'
+          report_paths: 'account-service/build/test-results/test/TEST-*.xml'

--- a/account-service/src/main/java/com/synapse/account_service/common/BaseEntity.java
+++ b/account-service/src/main/java/com/synapse/account_service/common/BaseEntity.java
@@ -1,0 +1,20 @@
+package com.synapse.account_service.common;
+
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity extends BaseTimeEntity {
+    @CreatedBy
+    @Column(updatable = false)
+    private String createdBy;
+
+    @LastModifiedBy
+    private String lastModifiedBy;
+}

--- a/account-service/src/main/java/com/synapse/account_service/common/BaseTimeEntity.java
+++ b/account-service/src/main/java/com/synapse/account_service/common/BaseTimeEntity.java
@@ -1,0 +1,22 @@
+package com.synapse.account_service.common;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime updatedDate;
+}

--- a/account-service/src/main/java/com/synapse/account_service/config/JpaAuditingConfig.java
+++ b/account-service/src/main/java/com/synapse/account_service/config/JpaAuditingConfig.java
@@ -1,0 +1,10 @@
+package com.synapse.account_service.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+
+}

--- a/account-service/src/main/java/com/synapse/account_service/domain/Member.java
+++ b/account-service/src/main/java/com/synapse/account_service/domain/Member.java
@@ -1,0 +1,57 @@
+package com.synapse.account_service.domain;
+
+import java.util.List;
+
+import org.springframework.security.core.GrantedAuthority;
+
+import com.synapse.account_service.common.BaseEntity;
+import com.synapse.account_service.domain.enums.MemberRole;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "members")
+public class Member extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long id;
+
+    @Column(name = "username")
+    private String username;
+
+    @Column(name = "password")
+    private String password;
+
+    @Column(name = "email", nullable = false, unique = true, length = 50)
+    private String email;
+
+    @Column(name = "provider", length = 10)
+    private String provider;
+
+    @Column(name = "picture", columnDefinition = "TEXT")
+    private String picture;
+
+    @Column(name = "registration_id")
+    private String registrationId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MemberRole role;
+
+    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+    private Subscription subscription;
+
+    @Builder
+    public Member(String username, String password, String email, String provider, String picture, String registrationId, MemberRole role) {
+        this.username = username;
+        this.password = password;
+        this.email = email;
+        this.provider = provider;
+        this.picture = picture;
+    }
+}

--- a/account-service/src/main/java/com/synapse/account_service/domain/Subscription.java
+++ b/account-service/src/main/java/com/synapse/account_service/domain/Subscription.java
@@ -1,0 +1,37 @@
+package com.synapse.account_service.domain;
+
+import java.time.ZonedDateTime;
+
+import com.synapse.account_service.common.BaseTimeEntity;
+import com.synapse.account_service.domain.enums.SubscriptionTier;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "subscription")
+public class Subscription extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "subscription_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(name = "tier", nullable = false)
+    private SubscriptionTier tier = SubscriptionTier.FREE;
+
+    @Column(name = "next_renewal_date", nullable = false)
+    private ZonedDateTime nextRenewalDate;
+
+    @Builder
+    public Subscription(Member member, SubscriptionTier tier, ZonedDateTime nextRenewalDate) {
+        this.member = member;
+        this.tier = tier;
+        this.nextRenewalDate = nextRenewalDate;
+    }
+}

--- a/account-service/src/main/java/com/synapse/account_service/domain/enums/MemberRole.java
+++ b/account-service/src/main/java/com/synapse/account_service/domain/enums/MemberRole.java
@@ -1,0 +1,5 @@
+package com.synapse.account_service.domain.enums;
+
+public enum MemberRole {
+    USER, ADMIN
+}

--- a/account-service/src/main/java/com/synapse/account_service/domain/enums/SubscriptionTier.java
+++ b/account-service/src/main/java/com/synapse/account_service/domain/enums/SubscriptionTier.java
@@ -1,0 +1,6 @@
+package com.synapse.account_service.domain.enums;
+
+public enum SubscriptionTier {
+    FREE,
+    PRO
+}


### PR DESCRIPTION
## ✨ PR 작업 내용

- Member, Subscription 엔티티 구현
- BaseEntity로 공통 필드 관리
- 회원 역할 및 구독 등급 enum 추가

## 이미지 첨부

<img src="파일 주소" width="50%" height="50%">
<br/>

## 다음 할 일

- 다음으로 할 일을 작성해 주세요.