### PR TITLE
feat : 네이버 소셜 로그인 기능 구현 및 OIDC 지원 추가

### DIFF
--- a/account-service/src/main/java/com/synapse/account_service/config/SecurityConfig.java
+++ b/account-service/src/main/java/com/synapse/account_service/config/SecurityConfig.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.synapse.account_service.convert.authority.CustomAuthorityMapper;
 import com.synapse.account_service.filter.JwtAuthenticationFilter;
 import com.synapse.account_service.service.CustomOAuth2UserService;
+import com.synapse.account_service.service.CustomOidcUserService;
 import com.synapse.account_service.service.CustomUserDetailsService;
 import com.synapse.account_service.service.handler.LoginFailureHandler;
 import com.synapse.account_service.service.handler.LoginSuccessHandler;
@@ -32,6 +33,7 @@ public class SecurityConfig {
     private final LoginSuccessHandler loginSuccessHandler;
     private final LoginFailureHandler loginFailureHandler;
     private final CustomOAuth2UserService customOAuth2UserService;
+    private final CustomOidcUserService customOidcUserService;
     private final ObjectMapper objectMapper;
     private final PasswordEncoder passwordEncoder;
 
@@ -48,7 +50,10 @@ public class SecurityConfig {
             .addFilterAt(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
 
             .oauth2Login(oauth2 -> oauth2
-                .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
+                .userInfoEndpoint(userInfo -> userInfo
+                    .userService(customOAuth2UserService)
+                    .oidcUserService(customOidcUserService)
+                )
                 .successHandler(loginSuccessHandler)
                 .failureHandler(loginFailureHandler)
             )

--- a/account-service/src/main/java/com/synapse/account_service/convert/DelegatingProviderUserConverter.java
+++ b/account-service/src/main/java/com/synapse/account_service/convert/DelegatingProviderUserConverter.java
@@ -22,7 +22,9 @@ public final class DelegatingProviderUserConverter implements ProviderUserConver
                 new UserDetailsProviderUserConverter(),
                 new OAuth2GoogleProviderUserConverter(),
                 new OAuth2KakaoProviderUserConverter(),
-                new OAuth2KakaoOidcProviderUserConverter());
+                new OAuth2KakaoOidcProviderUserConverter(),
+                new OAuth2NaverProviderUserConverter()
+        );
 
         this.converters = Collections.unmodifiableList(new LinkedList<>(providerUserConverters));
     }

--- a/account-service/src/main/java/com/synapse/account_service/convert/OAuth2NaverProviderUserConverter.java
+++ b/account-service/src/main/java/com/synapse/account_service/convert/OAuth2NaverProviderUserConverter.java
@@ -1,0 +1,22 @@
+package com.synapse.account_service.convert;
+
+import com.synapse.account_service.domain.ProviderUser;
+import com.synapse.account_service.domain.enums.OAuth2Config;
+import com.synapse.account_service.domain.socials.NaverUser;
+import com.synapse.account_service.util.OAuth2Utils;
+
+public final class OAuth2NaverProviderUserConverter implements ProviderUserConverter<ProviderUserRequest, ProviderUser> {
+
+    @Override
+    public ProviderUser convert(ProviderUserRequest providerUserRequest) {
+
+        if (!providerUserRequest.clientRegistration().getRegistrationId().equals(OAuth2Config.SocialType.NAVER.getSocialName())) {
+            return null;
+        }
+
+        return new NaverUser(OAuth2Utils.getSubAttributes(
+                providerUserRequest.oAuth2User(), "response"),
+                providerUserRequest.oAuth2User(),
+                providerUserRequest.clientRegistration());
+    }
+}

--- a/account-service/src/main/java/com/synapse/account_service/domain/enums/OAuth2Config.java
+++ b/account-service/src/main/java/com/synapse/account_service/domain/enums/OAuth2Config.java
@@ -3,7 +3,9 @@ package com.synapse.account_service.domain.enums;
 public class OAuth2Config {
     public enum SocialType {
         GOOGLE("google"),
-        KAKAO("kakao");
+        KAKAO("kakao"),
+        NAVER("naver")
+        ;
 
         private final String socialName;
 

--- a/account-service/src/main/java/com/synapse/account_service/domain/socials/NaverUser.java
+++ b/account-service/src/main/java/com/synapse/account_service/domain/socials/NaverUser.java
@@ -1,0 +1,28 @@
+package com.synapse.account_service.domain.socials;
+
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import com.synapse.account_service.domain.Attributes;
+
+public class NaverUser extends OAuth2ProviderUser {
+
+    public NaverUser(Attributes attributes, OAuth2User oAuth2User, ClientRegistration clientRegistration) {
+        super(attributes.getSubAttributes(), oAuth2User, clientRegistration);
+    }
+
+    @Override
+    public String getId() {
+        return (String) getAttributes().get("id");
+    }
+
+    @Override
+    public String getUsername() {
+        return (String) getAttributes().get("name");
+    }
+
+    @Override
+    public String getPicture() {
+        return (String) getAttributes().get("profile_image");
+    }
+}

--- a/account-service/src/main/java/com/synapse/account_service/exception/ExceptionType.java
+++ b/account-service/src/main/java/com/synapse/account_service/exception/ExceptionType.java
@@ -18,6 +18,7 @@ public enum ExceptionType {
     DUPLICATED_USERNAME(CONFLICT, "002", "이미 존재하는 사용자 이름입니다."),
     EXCEPTION(INTERNAL_SERVER_ERROR, "003", "예상치 못한 오류가 발생했습니다."),
     NOT_FOUND_MEMBER(NOT_FOUND, "004", "존재하지 않는 사용자입니다."),
+    DUPLICATED_USERNAME_AND_EMAIL(CONFLICT, "005", "이미 존재하는 사용자 이름과 이메일입니다."),
 
     INVALID_TOKEN(UNAUTHORIZED, "005", "유효하지 않은 토큰입니다."),
     EXPIRED_TOKEN(UNAUTHORIZED, "006", "만료된 토큰입니다."),

--- a/account-service/src/main/java/com/synapse/account_service/repository/MemberRepository.java
+++ b/account-service/src/main/java/com/synapse/account_service/repository/MemberRepository.java
@@ -14,6 +14,9 @@ public interface MemberRepository extends JpaRepository<Member, UUID> {
     Optional<Member> findByUsername(String username);
     Optional<Member> findByProviderAndRegistrationId(String provider, String registrationId);
 
+    @Query("SELECT m FROM Member m WHERE m.username = :username AND m.email = :email")
+    Optional<Member> findByUsernameAndEmail(@Param("username") String username, @Param("email") String email);
+
     @Query("SELECT m FROM Member m WHERE (m.provider = :provider AND m.registrationId = :registrationId) OR m.email = :email OR m.username = :username")
     Optional<Member> findBySocialIdOrEmailOrUsername(@Param("provider") String provider, @Param("registrationId") String registrationId, @Param("email") String email, @Param("username") String username);
 }

--- a/account-service/src/main/java/com/synapse/account_service/service/AccountService.java
+++ b/account-service/src/main/java/com/synapse/account_service/service/AccountService.java
@@ -48,11 +48,8 @@ public class AccountService {
 
     private Member createAndSaveNewMember(String email, String username, String password, String provider, String registrationId) {
         // 중복 검사
-        memberRepository.findByEmail(email).ifPresent(m -> {
-            throw new DuplicatedException(ExceptionType.DUPLICATED_EMAIL);
-        });
-        memberRepository.findByUsername(username).ifPresent(m -> {
-            throw new DuplicatedException(ExceptionType.DUPLICATED_USERNAME);
+        memberRepository.findByUsernameAndEmail(username, email).ifPresent(m -> {
+            throw new DuplicatedException(ExceptionType.DUPLICATED_USERNAME_AND_EMAIL);
         });
 
         Member member = Member.builder()

--- a/account-service/src/main/java/com/synapse/account_service/util/OAuth2Utils.java
+++ b/account-service/src/main/java/com/synapse/account_service/util/OAuth2Utils.java
@@ -16,6 +16,15 @@ public class OAuth2Utils {
     }
 
     @SuppressWarnings("unchecked")
+    public static Attributes getSubAttributes(OAuth2User oAuth2User, String subAttributesKey) {
+
+        Map<String, Object> subAttributes = (Map<String, Object>) oAuth2User.getAttributes().get(subAttributesKey);
+        return Attributes.builder()
+                .subAttributes(subAttributes)
+                .build();
+    }
+
+    @SuppressWarnings("unchecked")
     public static Attributes getOtherAttributes(OAuth2User oAuth2User, String subAttributesKey, String otherAttributesKey) {
         
         Map<String, Object> subAttributes = (Map<String, Object>) oAuth2User.getAttributes().get(subAttributesKey);

--- a/account-service/src/main/resources/application-local.yml
+++ b/account-service/src/main/resources/application-local.yml
@@ -13,7 +13,7 @@ spring:
         highlight:
             sql: true
         hbm2ddl:
-            auto: create-drop
+            auto: create
         dialect: org.hibernate.dialect.PostgreSQLDialect
     open-in-view: false
     show-sql: true

--- a/account-service/src/main/resources/application.yml
+++ b/account-service/src/main/resources/application.yml
@@ -15,3 +15,4 @@ spring:
         import:
             - security/application-db.yml
             - security/application-jwt.yml
+            - security/application-oauth2.yml

--- a/account-service/src/test/java/com/synapse/account_service/service/AccountServiceTest.java
+++ b/account-service/src/test/java/com/synapse/account_service/service/AccountServiceTest.java
@@ -41,8 +41,7 @@ public class AccountServiceTest {
         // given: 테스트 준비
         SignUpRequest request = new SignUpRequest("test@example.com", "테스트유저", "password123");
         
-        given(memberRepository.findByEmail(anyString())).willReturn(Optional.empty());
-        given(memberRepository.findByUsername(anyString())).willReturn(Optional.empty());
+        given(memberRepository.findByUsernameAndEmail(anyString(), anyString())).willReturn(Optional.empty());
         given(passwordEncoder.encode(anyString())).willReturn("encodedPassword");
         given(memberRepository.save(any(Member.class))).willAnswer(invocation -> {
             Member memberToSave = invocation.getArgument(0);
@@ -61,15 +60,15 @@ public class AccountServiceTest {
     }
 
     @Test
-    @DisplayName("이메일 중복으로 회원가입 실패")
-    void signUp_fail_withDuplicateEmail() {
+    @DisplayName("이메일 또는 사용자명 중복으로 회원가입 실패")
+    void signUp_fail_withDuplicateUsernameAndEmail() {
         // given
         SignUpRequest request = new SignUpRequest("test@example.com", "테스트유저", "password123");
         
-        // memberRepository.findByEmail이 호출되면, 이미 존재하는 Member 객체를 반환하도록 설정
-        given(memberRepository.findByEmail(anyString())).willReturn(Optional.of(Member.builder().build()));
+        // memberRepository.findByUsernameAndEmail이 호출되면, 이미 존재하는 Member 객체를 반환하도록 설정
+        given(memberRepository.findByUsernameAndEmail(anyString(), anyString())).willReturn(Optional.of(Member.builder().build()));
         
-        // when & then: BusinessException이 발생하는지 검증
+        // when & then: DuplicatedException이 발생하는지 검증
         assertThrows(DuplicatedException.class, () -> {
             accountService.registerMember(request);
         });


### PR DESCRIPTION
## 📌 관련 이슈

- closed: #14

## ✨ PR 작업 내용

- **네이버 소셜 로그인 연동**: 사용자가 네이버 계정으로 서비스에 가입하고 로그인할 수 있도록 OAuth2 클라이언트를 구현했습니다. 네이버 API의 고유한 응답 형식을 처리하는 로직을 포함합니다.
- **OIDC(OpenID Connect) 지원 추가**: `SecurityConfig`에 `CustomOidcUserService`를 등록하여, 기존 OAuth2 방식과 함께 OIDC 기반의 인증을 처리할 수 있도록 시스템을 확장했습니다.
- **회원 중복 검사 로직 개선**: 신규 회원 가입 시 사용자 이름과 이메일의 중복 여부를 하나의 쿼리로 동시에 검사하도록 리팩토링하여 DB 조회를 최적화했습니다.

## 이미지 첨부

<img src="파일 주소" width="50%" height="50%">
<br/>

## 다음 할 일

- 다음으로 할 일을 작성해 주세요.